### PR TITLE
Fix redefine shortcuts section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,41 @@ Enjoy!
 - Ctrl + Shift + t
 - Cmd + Shift + t (Mac)
 
-## Redine shortcuts:
+## Change keybinding:
 
+Within VSCode (last tested in v1.56.1):
+1. Open _Keyboard Shortcuts_ menu (`ctrl+k ctrl+s` for windows, `cmd+k cmd+s` for mac)
+1. Search for `Go to test`
+1. Hover over this extension's shortcut (identified by `extension.goToTest`) and click on the edit icon to the left (looks like a pencil)
+1. Press a key combination and save to overwrite the default keybinding
 
-In keybindings.json
+Alternatively,
+
+In `keybindings.json`:
 
 ```
-  ...
-	{
-		"key": "shift-cmd-t",
-		"command": "extension.railsGoToTest",
-		"when": "editorFocus"
-	}
+[
 	...
+	{
+		"key": "alt+cmd+t", // Your chosen combination
+		"command": "extension.goToTest",
+		"when": "editorTextFocus"
+	},
+	...
+]
+```
+
+Shortcuts defined here will work in-addition-to whatever keybinding is specified in the _Keyboard Shortcuts_ menu.
+If you wish to **replace** the default keybinding, add the following to `keybindings.json`:
+
+```
+[
+	...
+	{
+		"key": "shift+cmd+t",
+		"command": "-extension.goToTest", // Notice the `-` sign
+		"when": "editorTextFocus"
+	},
+	...
+]
 ```

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Enjoy!
 
 Within VSCode (last tested in v1.56.1):
 1. Open _Keyboard Shortcuts_ menu (`ctrl+k ctrl+s` for windows, `cmd+k cmd+s` for mac)
-1. Search for `Go to test`
-1. Hover over this extension's shortcut (identified by `extension.goToTest`) and click on the edit icon to the left (looks like a pencil)
-1. Press a key combination and save to overwrite the default keybinding
+2. Search for `Go to test`
+3. Hover over this extension's shortcut (identified by `extension.goToTest`) and click on the edit icon to the left (looks like a pencil)
+4. Press a key combination and save to overwrite the default keybinding
 
 Alternatively,
 


### PR DESCRIPTION
Our "redefine shortcuts" section specified the extension identifier
as `extension.railsGoToTest`, when it is actually `extension.goToTest`.
This fixes that and adds clearer instructions regarding changes
in keybindings.